### PR TITLE
ProfileMiniCard crashing the app

### DIFF
--- a/src/components/popovers/ProfileMiniCard.tsx
+++ b/src/components/popovers/ProfileMiniCard.tsx
@@ -30,11 +30,11 @@ export const ProfileMiniCard: React.FC<ProfileMiniCardProps> = ({
   const deckCount = allDecks.filter(
     (deck) => deck.userId === profile.id,
   ).length;
-  const totalWins = Object.values(profile.formatStats).reduce(
+  const totalWins = Object.values(profile?.formatStats ?? {}).reduce(
     (acc, value) => acc + value.gamesWon,
     0,
   );
-  const totalMatches = Object.values(profile.formatStats).reduce(
+  const totalMatches = Object.values(profile?.formatStats ?? {}).reduce(
     (acc, value) => acc + value.gamesPlayed,
     0,
   );


### PR DESCRIPTION
ProfileMiniCard set up in a way that if the user does not have a `formatStats` property on their profile data, it would cause a fatal type error when it attempted to render. That's less than ideal so this offers fallbacks to the `profile?.formatStats` accessor