### PR TITLE
Add "forgot password" flow for user onboarding

### DIFF
--- a/src/components/pages/LoginPage.tsx
+++ b/src/components/pages/LoginPage.tsx
@@ -15,13 +15,36 @@ import { useState } from "react";
 
 import { useAuth } from "@/hooks";
 
+type AuthMode = "signIn" | "forgotPassword" | "forgotPasswordConfirm";
+
 export const LoginPage = () => {
+  const {
+    signIn,
+    completeNewPasswordChallenge,
+    forgotPassword,
+    confirmForgotPassword,
+    isAuthenticated,
+    newPasswordChallenge,
+  } = useAuth();
+
+  const [authMode, setAuthMode] = useState<AuthMode>("signIn");
+
+  // user auth inputs
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+
+  // forgot password flow inputs
+  const [forgotEmail, setForgotEmail] = useState("");
+  const [forgotCode, setForgotCode] = useState("");
+  const [forgotNewPassword, setForgotNewPassword] = useState("");
+
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  const { signIn, isAuthenticated } = useAuth();
+  if (isAuthenticated) {
+    navigate("/users");
+  }
 
   const handleSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -29,17 +52,152 @@ export const LoginPage = () => {
     setError(null);
 
     try {
-      await signIn(username, password);
+      if (newPasswordChallenge) {
+        await completeNewPasswordChallenge(newPassword);
+      } else if (authMode === "signIn") {
+        await signIn(username, password);
+      } else if (authMode === "forgotPassword") {
+        await forgotPassword(forgotEmail);
+        setAuthMode("forgotPasswordConfirm");
+      } else if (authMode === "forgotPasswordConfirm") {
+        await confirmForgotPassword(forgotEmail, forgotCode, forgotNewPassword);
+        setAuthMode("signIn");
+      }
     } catch (err: any) {
-      setError(err?.message || "login failed");
+      setError(err?.message ?? "operation failed");
     } finally {
       setLoading(false);
     }
   };
 
-  if (isAuthenticated) {
-    navigate("/users");
-  }
+  const renderModeSwitch = () => {
+    if (newPasswordChallenge) {
+      return null;
+    }
+
+    return (
+      <Button
+        onClick={() =>
+          setAuthMode(authMode === "signIn" ? "forgotPassword" : "signIn")
+        }
+      >
+        {authMode === "signIn" ? "forgot password?" : "back to sign-in"}
+      </Button>
+    );
+  };
+
+  const renderFormFields = () => {
+    if (newPasswordChallenge) {
+      return (
+        <TextField
+          fullWidth
+          required
+          label="new password"
+          type="password"
+          margin="normal"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+      );
+    }
+
+    if (authMode === "forgotPassword") {
+      return (
+        <TextField
+          fullWidth
+          required
+          label="email"
+          margin="normal"
+          value={forgotEmail}
+          onChange={(e) => setForgotEmail(e.target.value)}
+        />
+      );
+    }
+
+    if (authMode === "forgotPasswordConfirm") {
+      return (
+        <>
+          <TextField
+            fullWidth
+            required
+            label="verification code"
+            margin="normal"
+            value={forgotCode}
+            onChange={(e) => setForgotCode(e.target.value)}
+          />
+          <TextField
+            fullWidth
+            required
+            label="new password"
+            type="password"
+            margin="normal"
+            value={forgotNewPassword}
+            onChange={(e) => setForgotNewPassword(e.target.value)}
+          />
+        </>
+      );
+    }
+
+    return (
+      <>
+        <TextField
+          fullWidth
+          required
+          label="username"
+          margin="normal"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          autoComplete="username"
+        />
+        <TextField
+          fullWidth
+          required
+          label="password"
+          type="password"
+          margin="normal"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          autoComplete="current-password"
+        />
+      </>
+    );
+  };
+
+  const getHeading = () => {
+    if (newPasswordChallenge) {
+      return "set new password";
+    }
+
+    if (authMode === "forgotPassword") {
+      return "forgot password";
+    }
+
+    if (authMode === "forgotPasswordConfirm") {
+      return "reset your password";
+    }
+
+    return "sign in";
+  };
+
+  const getButtonText = () => {
+    if (loading) {
+      return <CircularProgress size={24} />;
+    }
+
+    if (newPasswordChallenge) {
+      return "set password";
+    }
+
+    if (authMode === "forgotPassword") {
+      return "send verification code";
+    }
+
+    if (authMode === "forgotPasswordConfirm") {
+      return "reset password";
+    }
+
+    return "sign in";
+  };
 
   return (
     <Stack alignItems="center" justifyContent="center" sx={{ height: "100%" }}>
@@ -52,7 +210,7 @@ export const LoginPage = () => {
             <LockOutlinedIcon />
           </Avatar>
           <Typography component="h1" variant="h5">
-            sign in
+            {getHeading()}
           </Typography>
           {error && (
             <Alert severity="error" sx={{ mt: 2, width: "100%" }}>
@@ -64,25 +222,7 @@ export const LoginPage = () => {
             onSubmit={handleSubmit}
             sx={{ mt: 3, width: "100%" }}
           >
-            <TextField
-              fullWidth
-              required
-              label="username"
-              margin="normal"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              autoComplete="username"
-            />
-            <TextField
-              fullWidth
-              required
-              label="password"
-              type="password"
-              margin="normal"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              autoComplete="current-password"
-            />
+            {renderFormFields()}
             <Button
               type="submit"
               fullWidth
@@ -90,9 +230,10 @@ export const LoginPage = () => {
               disabled={loading}
               sx={{ mt: 3, mb: 2 }}
             >
-              {loading ? <CircularProgress size={24} /> : "sign in"}
+              {getButtonText()}
             </Button>
           </Box>
+          {renderModeSwitch()}
         </Stack>
       </Paper>
     </Stack>

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,13 +1,21 @@
 // Context/AuthContext.tsx
 import {
   AuthFlowType,
+  ConfirmForgotPasswordCommand,
+  ForgotPasswordCommand,
   InitiateAuthCommand,
+  RespondToAuthChallengeCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 import { navigate } from "raviger";
 import { PropsWithChildren, createContext, useEffect, useState } from "react";
 
 import { AWS_COGNITO_CLIENT_ID } from "@/constants";
 import { cognitoClient } from "@/lib";
+
+interface NewPasswordChallenge {
+  email: string;
+  session: string;
+}
 
 interface AuthContextType {
   userId: string | null;
@@ -16,6 +24,14 @@ interface AuthContextType {
   isInitializing: boolean;
   signIn: (email: string, password: string) => Promise<void>;
   signOut: () => void;
+  completeNewPasswordChallenge: (newPassword: string) => Promise<void>;
+  newPasswordChallenge?: NewPasswordChallenge;
+  forgotPassword: (email: string) => Promise<void>;
+  confirmForgotPassword: (
+    email: string,
+    code: string,
+    newPassword: string,
+  ) => Promise<void>;
   accessToken: string | null;
   refreshSession: () => Promise<void>;
 }
@@ -30,6 +46,9 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
   const [accessToken, setAccessToken] = useState<string | null>(null);
   const [refreshToken, setRefreshToken] = useState<string | null>(null);
   const [isInitializing, setIsInitializing] = useState(true);
+  const [newPasswordChallenge, setNewPasswordChallenge] = useState<
+    NewPasswordChallenge | undefined
+  >(undefined);
 
   useEffect(() => {
     const storedAccessToken = localStorage.getItem("accessToken");
@@ -49,7 +68,7 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
         console.warn("failed to decode JWT during session restore");
       }
 
-      // 👇 TRY refreshing session to validate token and get new one if needed
+      // try refreshing session to validate token and get new one if needed
       refreshSession().catch((err) => {
         console.warn("token refresh failed", err);
         signOut();
@@ -70,16 +89,28 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
     });
 
     const response = await cognitoClient.send(command);
+
+    // check if cognito requires the user to set a new password
+    if (response.ChallengeName === "NEW_PASSWORD_REQUIRED") {
+      // store the necessary state and let the ui prompt for the new password
+      setNewPasswordChallenge({
+        email,
+        // session token required for the challenge response
+        session: response.Session!,
+      });
+      return;
+    }
+
     const authResult = response.AuthenticationResult;
     if (!authResult) {
       throw new Error("login failed");
     }
 
     const { AccessToken, RefreshToken } = authResult;
-
     let userId: string;
-    let groups: string[];
+    let groups: string[] = [];
     let isAdmin = false;
+
     try {
       const payload = JSON.parse(atob(AccessToken!.split(".")[1]));
       userId = payload.sub;
@@ -114,6 +145,80 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
     setIsAdmin(false);
 
     navigate("/");
+  };
+
+  const completeNewPasswordChallenge = async (newPassword: string) => {
+    if (!newPasswordChallenge) {
+      throw new Error("no password change challenge pending");
+    }
+
+    const command = new RespondToAuthChallengeCommand({
+      ChallengeName: "NEW_PASSWORD_REQUIRED",
+      ClientId: AWS_COGNITO_CLIENT_ID,
+      ChallengeResponses: {
+        USERNAME: newPasswordChallenge.email,
+        NEW_PASSWORD: newPassword,
+      },
+      Session: newPasswordChallenge.session,
+    });
+
+    const response = await cognitoClient.send(command);
+    const authResult = response.AuthenticationResult;
+    if (!authResult) {
+      throw new Error("password change failed");
+    }
+
+    // parse the token and update state as before
+    const { AccessToken, RefreshToken } = authResult;
+    let userId: string;
+    let groups: string[] = [];
+    let isAdmin = false;
+
+    try {
+      const payload = JSON.parse(atob(AccessToken!.split(".")[1]));
+      userId = payload.sub;
+      groups = payload["cognito:groups"] || [];
+      isAdmin = groups.includes("admin");
+    } catch {
+      throw new Error("invalid access token");
+    }
+
+    // store tokens and update the authentication state
+    localStorage.setItem("accessToken", AccessToken!);
+    localStorage.setItem("refreshToken", RefreshToken!);
+    localStorage.setItem("userId", userId);
+
+    setAccessToken(AccessToken!);
+    setRefreshToken(RefreshToken!);
+    setUserId(userId);
+    setIsAdmin(isAdmin);
+
+    // clear the pending challenge after completion
+    setNewPasswordChallenge(undefined);
+
+    navigate("/users");
+  };
+
+  const forgotPassword = async (email: string) => {
+    const command = new ForgotPasswordCommand({
+      ClientId: AWS_COGNITO_CLIENT_ID,
+      Username: email,
+    });
+    await cognitoClient.send(command);
+  };
+
+  const confirmForgotPassword = async (
+    email: string,
+    code: string,
+    newPassword: string,
+  ) => {
+    const command = new ConfirmForgotPasswordCommand({
+      ClientId: AWS_COGNITO_CLIENT_ID,
+      Username: email,
+      ConfirmationCode: code,
+      Password: newPassword,
+    });
+    await cognitoClient.send(command);
   };
 
   const refreshSession = async () => {
@@ -155,6 +260,9 @@ export const AuthProvider = ({ children }: PropsWithChildren<{}>) => {
         accessToken,
         signIn,
         signOut,
+        completeNewPasswordChallenge,
+        forgotPassword,
+        confirmForgotPassword,
         refreshSession,
         isAdmin,
         isInitializing,


### PR DESCRIPTION
The temporary passwords sent out in the initial batch of users being onboarded have a set expiration date, this additional flow should allow those users to reset their passwords using the native cognito password reset/new password challenge flows to avoid them having to go to the specific cognito userpool's password reset page